### PR TITLE
Allow flashing with newer Trustzone version

### DIFF
--- a/board-info.txt
+++ b/board-info.txt
@@ -1,1 +1,1 @@
-require version-trustzone=TZ.BF.2.0-2.0.0109|TZ.BF.2.0-2.0.0123|TZ.BF.2.0-2.0.0134
+require version-trustzone=TZ.BF.2.0-2.0.0109|TZ.BF.2.0-2.0.0123|TZ.BF.2.0-2.0.0134|TZ.BF.2.0-2.0.0137


### PR DESCRIPTION
Onyx devices with OOS 3.1.4 assert TZ version TZ.BF.2.0-2.0.0137; we can't commonize until this edit is made.